### PR TITLE
Yarn support.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,8 +4,8 @@ Copyright (c) 2014 swarajban
 Copyright (c) 2017 REISS Ltd.
 
 Copyright for portions of project package-cache are held by swarajban, 2014
-as part of project project npm-cache. All other copyright for project
-package-cache are held by REISS Ltd, 2017.
+as part of project npm-cache. All other copyright for project package-cache
+are held by REISS Ltd, 2017.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 package-cache
 =========
 
-`package-cache` is a command line utility that caches dependencies installed via `yarn`, ``npm`, `bower`, `jspm` and `composer`.
+`package-cache` is a command line utility that caches dependencies installed via `yarn`, `npm`, `bower`, `jspm`
+and `composer`.
 
 It is useful for build processes that run `[yarn|npm|bower|composer|jspm] install` every time as part of their
 build process. Since dependencies don't change often, this often means slower build times. `package-cache`
@@ -47,9 +48,3 @@ package-cache install --forceRefresh  bower	# force installing dependencies from
 package-cache install --noArchive  npm	# installs dependencies and caches them without compressing
 package-cache clean	# cleans out all cached files in cache directory
 ```
-
-## Contributing
-Though I have a busy day job, I will do my best to add simple feature requests and
-merge PRs as soon as I can. I know this package is not following many of today's best
-practices (namely TESTS, a proper branching strategy, and more), but I hope you still
-find it useful.

--- a/cacheDependencyManagers/yarnConfig.js
+++ b/cacheDependencyManagers/yarnConfig.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var path = require('path');
+var shell = require('shelljs');
+var fs = require('fs');
+var md5 = require('md5');
+var logger = require('../util/logger');
+var isUsingYarnLock = null;
+
+/**
+ * Returns path to configuration file for yarn.
+ * Uses yarn.lock
+ *
+ * @returns {string}
+ */
+function getConfigPath() {
+  var yarnLockPath = path.resolve(process.cwd(), 'yarn.lock');
+  var packageJsonPath = path.resolve(process.cwd(), 'package.json');
+
+  if (isUsingYarnLock === null) {
+      if (fs.existsSync(yarnLockPath)) {
+          logger.logInfo('[yarn] using yarn.lock instead of package.json');
+          isUsingYarnLock = true;
+      } else {
+          isUsingYarnLock = false;
+      }
+  }
+
+  return isUsingYarnLock ? yarnLockPath : packageJsonPath;
+}
+
+/**
+ * @param {string} filePath
+ *
+ * @returns {string} MD5 Hash
+ */
+function getConfigHash(filePath) {
+  if (isUsingYarnLock) {
+      return md5(fs.readFileSync(filePath));
+  }
+
+  var config = JSON.parse(fs.readFileSync(filePath));
+
+  return md5(JSON.stringify({
+      dependencies: config.dependencies,
+      devDependencies: config.devDependencies
+  }));
+}
+
+/**
+ *
+ * @returns {string}
+ */
+function getYarnVersion() {
+    return shell.exec('yarn --version', {silent: true}).output.trim();
+}
+
+module.exports = {
+  cliName: 'yarn',
+  getCliVersion: getYarnVersion,
+  configPath: getConfigPath(),
+  installDirectory: 'node_modules',
+  installCommand: 'yarn',
+  getFileHash: getConfigHash
+};

--- a/util/logger.js
+++ b/util/logger.js
@@ -7,4 +7,3 @@ exports.logError = function (errorMessage) {
 exports.logInfo = function (message) {
   console.log('[package-cache] [INFO] ' + message);
 };
-


### PR DESCRIPTION
By executing `package-cache install yarn`, you can now install
Node packages from a cache using those defined in a yarn.lock file
if one exists.

![screen shot 2017-03-06 at 16 21 26](https://cloud.githubusercontent.com/assets/5972864/23618672/fd4f4b76-0288-11e7-8712-af8e8fc35e56.png)

